### PR TITLE
Fix CachingLoaderDecorator and include tags

### DIFF
--- a/templates/lib/cachingloaderdecorator.cpp
+++ b/templates/lib/cachingloaderdecorator.cpp
@@ -88,8 +88,10 @@ QPair< QString, QString > CachingLoaderDecorator::getMediaUri( const QString& fi
 Template CachingLoaderDecorator::loadByName( const QString& name, const Grantlee::Engine* engine ) const
 {
   Q_D( const CachingLoaderDecorator );
-  if ( d->m_cache.contains( name ) )
-    return d->m_cache.value( name );
+  QHash<QString, Template>::ConstIterator it = d->m_cache.constFind(name);
+  if (it != d->m_cache.constEnd() && !it.value()->error()) {
+    return it.value();
+  }
 
   const Template t = d->m_wrappedLoader->loadByName( name, engine );
 


### PR DESCRIPTION
When using the CachingLoaderDecorator the behavior
of {% include var_for_dynamic_template %} is slightly changed as if a
previous rendering does not find the template
then the cache marks the template which has the include tag
as on error failing to render parent templates or next reder calls
a valid template.