### PR TITLE
Lowering needed CMAKE Version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 
 if (POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)

--- a/templates/lib/CMakeLists.txt
+++ b/templates/lib/CMakeLists.txt
@@ -62,29 +62,7 @@ add_library(Grantlee5::Templates ALIAS Grantlee_Templates)
 generate_export_header(Grantlee_Templates)
 set_property(TARGET Grantlee_Templates PROPERTY EXPORT_NAME Templates)
 
-if (Qt5Script_FOUND)
-  set(scriptabletags_FILES
-    scriptablecontext.cpp
-    scriptablefilterexpression.cpp
-    scriptablenode.cpp
-    scriptableparser.cpp
-    scriptablesafestring.cpp
-    scriptabletags.cpp
-    scriptabletemplate.cpp
-    scriptablevariable.cpp
-    scriptablefilter.cpp
-    )
-
-  foreach(file ${scriptabletags_FILES})
-    list(APPEND scriptabletags_SRCS ${CMAKE_SOURCE_DIR}/templates/scriptabletags/${file})
-  endforeach()
-
-  target_sources(Grantlee_Templates PRIVATE ${scriptabletags_SRCS})
-  target_include_directories(Grantlee_Templates PRIVATE ../scriptabletags)
-  target_link_libraries(Grantlee_Templates
-    LINK_PRIVATE Qt5::Script
-  )
-endif()
+target_include_directories(Grantlee_Templates PRIVATE ../scriptabletags)
 
 if (BUILD_TESTS)
   set(GRANTLEE_TESTS_EXPORT "GRANTLEE_TEMPLATES_EXPORT")


### PR DESCRIPTION
When building KDE Framework 5, this package is the only one with a dependency that is currently not in the debian stable release. This Pull-Request removes that dependency, so KDE Framework 5 can be build from latest sources on the latest stable system.