### PR TITLE
Add support for rendering associative containers

### DIFF
--- a/templates/defaulttags/for.cpp
+++ b/templates/defaulttags/for.cpp
@@ -24,6 +24,9 @@
 #include "metaenumvariable_p.h"
 #include "parser.h"
 
+#define FOR_LOOP "forloop"
+#define PARENT_LOOP "parentloop"
+
 ForNodeFactory::ForNodeFactory() {}
 
 Node *ForNodeFactory::getNode(const QString &tagContent, Parser *p) const
@@ -105,27 +108,17 @@ void ForNode::setEmptyList(const NodeList &emptyList)
   m_emptyNodeList = emptyList;
 }
 
-static const char forloop[] = "forloop";
-static const char parentloop[] = "parentloop";
-
 void ForNode::insertLoopVariables(Context *c, int listSize, int i)
 {
   // some magic variables injected into the context while rendering.
-  static const auto counter0 = QStringLiteral("counter0");
-  static const auto counter = QStringLiteral("counter");
-  static const auto revcounter0 = QStringLiteral("revcounter0");
-  static const auto revcounter = QStringLiteral("revcounter");
-  static const auto first = QStringLiteral("first");
-  static const auto last = QStringLiteral("last");
-
   auto forloopHash = c->lookup(QStringLiteral("forloop")).value<QVariantHash>();
-  forloopHash.insert(counter0, i);
-  forloopHash.insert(counter, i + 1);
-  forloopHash.insert(revcounter, listSize - i);
-  forloopHash.insert(revcounter0, listSize - i - 1);
-  forloopHash.insert(first, (i == 0));
-  forloopHash.insert(last, (i == listSize - 1));
-  c->insert(QLatin1String(forloop), forloopHash);
+  forloopHash.insert(QStringLiteral("counter0"), i);
+  forloopHash.insert(QStringLiteral("counter"), i + 1);
+  forloopHash.insert(QStringLiteral("revcounter"), listSize - i);
+  forloopHash.insert(QStringLiteral("revcounter0"), listSize - i - 1);
+  forloopHash.insert(QStringLiteral("first"), (i == 0));
+  forloopHash.insert(QStringLiteral("last"), (i == listSize - 1));
+  c->insert(QStringLiteral(FOR_LOOP), forloopHash);
 }
 
 void ForNode::renderLoop(OutputStream *stream, Context *c) const
@@ -266,12 +259,12 @@ void ForNode::render(OutputStream *stream, Context *c) const
 {
   QVariantHash forloopHash;
 
-  QVariant parentLoopVariant = c->lookup(QLatin1String(forloop));
+  QVariant parentLoopVariant = c->lookup(QStringLiteral(FOR_LOOP));
   if (parentLoopVariant.isValid()) {
     // This is a nested loop.
     forloopHash = parentLoopVariant.toHash();
-    forloopHash.insert(QLatin1String(parentloop), parentLoopVariant.toHash());
-    c->insert(QLatin1String(forloop), forloopHash);
+    forloopHash.insert(QStringLiteral(PARENT_LOOP), parentLoopVariant.toHash());
+    c->insert(QStringLiteral(FOR_LOOP), forloopHash);
   }
 
   bool unpack = m_loopVars.size() > 1;

--- a/templates/defaulttags/for.h
+++ b/templates/defaulttags/for.h
@@ -50,11 +50,11 @@ public:
 
 private:
   static void insertLoopVariables(Context *c, int listSize, int i);
-  void iterateHash(OutputStream *stream, Context *c,
-                   const QVariantHash &varHash, bool unpack);
   void renderLoop(OutputStream *stream, Context *c) const;
-  void handleHashItem(OutputStream *stream, Context *c, const QString &key,
-                      const QVariant &value, int listSize, int i, bool unpack);
+  inline void renderSequential(OutputStream *stream, Context *c, QVariant &varFE, bool unpack) const;
+  inline void renderAssociative(OutputStream *stream, Context *c, QVariant &varFE) const;
+  inline void renderAssociativeItem(OutputStream *stream, Context *c, const QString &keyName, const QString &valueName, const QVariant &key, const QVariant &value , int listSize, int i) const;
+  inline void renderAssociativeItemList(OutputStream *stream, Context *c, const QString &keyName, const QVariantList &values, int listSize, int i) const;
 
   QStringList m_loopVars;
   FilterExpression m_filterExpression;

--- a/templates/tests/testdefaulttags.cpp
+++ b/templates/tests/testdefaulttags.cpp
@@ -852,84 +852,18 @@ void TestDefaultTags::testForTag_data()
       << dict << QStringLiteral("xxl") << NoError;
 
   dict.clear();
-  QVariantHash hash;
-  //   hash.insert( QStringLiteral("one"), 1 );
-  //   hash.insert( QStringLiteral("two"), 2 );
-  //   dict.insert( QStringLiteral("items"), hash );
-  //   QTest::newRow( "for-tag-unpack-dict01" ) << QString::fromLatin1( "{%
-  //   for
-  //   key,value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //
-  //   QTest::newRow( "for-tag-unpack-dict03" ) << QString::fromLatin1( "{%
-  //   for
-  //   key, value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //   QTest::newRow( "for-tag-unpack-dict04" ) << QString::fromLatin1( "{%
-  //   for
-  //   key , value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //   QTest::newRow( "for-tag-unpack-dict05" ) << QString::fromLatin1( "{%
-  //   for
-  //   key ,value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //   QTest::newRow( "for-tag-unpack-dict06" ) << QString::fromLatin1( "{%
-  //   for
-  //   key value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //   QTest::newRow( "for-tag-unpack-dict07" ) << QString::fromLatin1( "{%
-  //   for
-  //   key,,value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //   QTest::newRow( "for-tag-unpack-dict08" ) << QString::fromLatin1( "{%
-  //   for
-  //   key,value, in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
-  //
-  //   // Ensure that a single loopvar doesn't truncate the list in val.
-  //   QTest::newRow( "for-tag-unpack-dict09" ) << QString::fromLatin1( "{%
-  //   for
-  //   val in items %}{{ val.0 }}:{{ val.1 }}/{% endfor %}" ) << dict <<
-  //   QString::fromLatin1( "one:1/two:2/" ) << NoError;
 
-  dict.clear();
-  list.clear();
-  QVariantList innerList;
-  innerList << QStringLiteral("one") << 1;
-  list.append(QVariant(innerList));
-  innerList.clear();
-  innerList << QStringLiteral("two") << 2;
-  list.append(QVariant(innerList));
-  dict.insert(QStringLiteral("items"), list);
-  QTest::newRow("for-tag-unpack01")
-      << QStringLiteral(
-             "{% for key,value in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
-
-  QTest::newRow("for-tag-unpack03")
-      << QStringLiteral(
-             "{% for key, value in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
-  QTest::newRow("for-tag-unpack04")
-      << QStringLiteral(
-             "{% for key , value in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
-  QTest::newRow("for-tag-unpack05")
-      << QStringLiteral(
-             "{% for key ,value in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
-  QTest::newRow("for-tag-unpack06")
-      << QStringLiteral(
-             "{% for key value in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
-  QTest::newRow("for-tag-unpack07")
-      << QStringLiteral(
-             "{% for key,,value in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
-  QTest::newRow("for-tag-unpack08")
-      << QStringLiteral(
-             "{% for key,value, in items %}{{ key }}:{{ value }}/{% endfor %}")
-      << dict << QStringLiteral("one:1/two:2/") << NoError;
+  QVariantMap map;// Hash has no predictable order
+  map.insert( QStringLiteral( "one" ), 1 );
+  map.insert( QStringLiteral( "two" ), 2 );
+  dict.insert( QStringLiteral( "items" ), map );
+  QTest::newRow( "for-tag-unpack01" ) << QStringLiteral( "{% for key,value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QStringLiteral( "one:1/two:2/" ) << NoError;
+  QTest::newRow( "for-tag-unpack03" ) << QStringLiteral( "{% for key, value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QStringLiteral( "one:1/two:2/" ) << NoError;
+  QTest::newRow( "for-tag-unpack04" ) << QStringLiteral( "{% for key , value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QStringLiteral( "one:1/two:2/" ) << NoError;
+  QTest::newRow( "for-tag-unpack05" ) << QStringLiteral( "{% for key ,value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QStringLiteral( "one:1/two:2/" ) << NoError;
+  QTest::newRow( "for-tag-unpack06" ) << QStringLiteral( "{% for key value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QString() << TagSyntaxError;
+  QTest::newRow( "for-tag-unpack07" ) << QStringLiteral( "{% for key,,value in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QString() << TagSyntaxError;
+  QTest::newRow( "for-tag-unpack08" ) << QStringLiteral( "{% for key,value, in items %}{{ key }}:{{ value }}/{% endfor %}" ) << dict << QString() << TagSyntaxError;
 
   // Ensure that a single loopvar doesn't truncate the list in val.
   QTest::newRow("for-tag-unpack09")
@@ -939,6 +873,8 @@ void TestDefaultTags::testForTag_data()
 
   // Otherwise, silently truncate if the length of loopvars differs to the
   // length of each set of items.
+
+  QVariantList innerList;
 
   dict.clear();
   list.clear();


### PR DESCRIPTION
Having a QVariant that can be converted to QVariantHash
or QVariantMap, is now rendered if a pair or single key
argument is provided, allowing template like this to
be valid:
{% for key, value in items %}
  {{ key }}:{{ value }}
{% endfo %}
The code also fixes some tests that should give syntax
errors, based on DJango tests.