### PR TITLE
Fix complex if operators

### DIFF
--- a/templates/defaulttags/if_p.h
+++ b/templates/defaulttags/if_p.h
@@ -301,21 +301,33 @@ QVariant IfToken::evaluate(Context *c) const
     case NotCode:
       return !Grantlee::variantIsTrue(mArgs.first->evaluate(c));
     case InCode:
-      return contains(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
+      return Grantlee::contains(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
     case NotInCode:
-      return !contains(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
+      return !Grantlee::contains(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
     case EqCode:
-      return mArgs.first->evaluate(c) == mArgs.second->evaluate(c);
+      return Grantlee::equals(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
     case NeqCode:
-      return mArgs.first->evaluate(c) != mArgs.second->evaluate(c);
+      return !Grantlee::equals(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
     case GtCode:
-      return mArgs.first->evaluate(c) > mArgs.second->evaluate(c);
+    {
+      const QVariant left = mArgs.first->evaluate(c);
+      const QVariant right = mArgs.second->evaluate(c);
+      return !Grantlee::lessThan(left, right) && !Grantlee::equals(left, right);
+    }
     case GteCode:
-      return mArgs.first->evaluate(c) >= mArgs.second->evaluate(c);
+    {
+      const QVariant left = mArgs.first->evaluate(c);
+      const QVariant right = mArgs.second->evaluate(c);
+      return !Grantlee::lessThan(left, right) || Grantlee::equals(left, right);
+    }
     case LtCode:
-      return mArgs.first->evaluate(c) < mArgs.second->evaluate(c);
+      return Grantlee::lessThan(mArgs.first->evaluate(c), mArgs.second->evaluate(c));
     case LteCode:
-      return mArgs.first->evaluate(c) <= mArgs.second->evaluate(c);
+    {
+      const QVariant left = mArgs.first->evaluate(c);
+      const QVariant right = mArgs.second->evaluate(c);
+      return Grantlee::lessThan(left, right) || Grantlee::equals(left, right);
+    }
     default:
       Q_ASSERT(!"Invalid OpCode");
       return QVariant();

--- a/templates/lib/engine.cpp
+++ b/templates/lib/engine.cpp
@@ -42,6 +42,7 @@ static const char __scriptableLibName[] = "grantlee_scriptabletags";
 Engine::Engine(QObject *parent)
     : QObject(parent), d_ptr(new EnginePrivate(this))
 {
+  QMetaType::registerComparators<SafeString>();
   d_ptr->m_defaultLibraries << QStringLiteral("grantlee_defaulttags")
                             << QStringLiteral("grantlee_loadertags")
                             << QStringLiteral("grantlee_defaultfilters");

--- a/templates/lib/safestring.cpp
+++ b/templates/lib/safestring.cpp
@@ -129,6 +129,21 @@ bool SafeString::operator==(const QString &other) const
   return m_nestedString == other;
 }
 
+bool SafeString::operator<(const SafeString &other) const
+{
+  return m_nestedString < other.get();
+}
+
+bool SafeString::operator<(const QString &other) const
+{
+  return m_nestedString < other;
+}
+
+bool SafeString::operator<(const QByteArray &other) const
+{
+  return m_nestedString < QString::fromUtf8(other);
+}
+
 SafeString &SafeString::NestedString::append(const SafeString &str)
 {
   QString::append(str.get());

--- a/templates/lib/safestring.h
+++ b/templates/lib/safestring.h
@@ -386,6 +386,27 @@ public:
   bool operator==(const QString &other) const;
 
   /**
+    Returns true if the content of @p other is less than the content of this.
+
+    Safeness and needing escaping are not accounted for in the comparison.
+  */
+  bool operator<( const SafeString &other ) const;
+
+  /**
+    Returns true if the content of @p other is less than the content of this.
+
+    Safeness and needing escaping are not accounted for in the comparison.
+  */
+  bool operator<( const QString &other ) const;
+
+  /**
+    Returns true if the content of @p other is less than the content of this.
+
+    Safeness and needing escaping are not accounted for in the comparison.
+  */
+  bool operator<( const QByteArray &other ) const;
+
+  /**
     Convenience operator for storing a SafeString in a QVariant.
   */
   operator QVariant() const { return QVariant::fromValue(*this); }

--- a/templates/lib/util.h
+++ b/templates/lib/util.h
@@ -85,6 +85,20 @@ GRANTLEE_TEMPLATES_EXPORT bool supportedOutputType(const QVariant &input);
 */
 GRANTLEE_TEMPLATES_EXPORT bool equals(const QVariant &lhs, const QVariant &rhs);
 
+/**
+  Compares @p lhs and @p rhs for less than. SafeStrings are compared as raw QStrings. Their safeness is not part of the comparison.
+
+  @see QVariant::operator<
+*/
+GRANTLEE_TEMPLATES_EXPORT bool lessThan(const QVariant &lhs, const QVariant &rhs);
+
+/**
+  Verify if rhs contains lhs, if both are strings they are contains is called, if rhs is a QStringList contains is called,
+  if rhs is QVariantList we iterate and use Grantlee::equals to see if each value matches lhs.
+  SafeStrings are compared as raw QStrings. Their safeness is not part of the comparison.
+*/
+GRANTLEE_TEMPLATES_EXPORT bool contains(const QVariant &lhs, const QVariant &rhs);
+
 #ifndef Q_QDOC
 /**
   @internal

--- a/templates/tests/testdefaulttags.cpp
+++ b/templates/tests/testdefaulttags.cpp
@@ -444,6 +444,16 @@ void TestDefaultTags::testIfTag_data()
       << QStringLiteral("{% if foo == \'\' %}yes{% else %}no{% endif %}")
       << dict << QStringLiteral("no") << NoError;
 
+  dict.clear();
+  QTest::newRow("if-tag-eq06")
+      << QStringLiteral("{% if \"foo\" == \"foo\" %}yes{% else %}no{% endif %}")
+      << dict << QStringLiteral("yes") << NoError;
+  dict.clear();
+  dict.insert(QStringLiteral("foo"), QStringLiteral("bar"));
+  QTest::newRow("if-tag-eq07")
+      << QStringLiteral("{% if foo == \"bar\" %}yes{% else %}no{% endif %}")
+      << dict << QStringLiteral("yes") << NoError;
+
   // Comparison
 
   dict.clear();
@@ -554,6 +564,33 @@ void TestDefaultTags::testIfTag_data()
   QTest::newRow("if-tag-operator-in-string06")
       << QStringLiteral("{% if color in colors %}yes{% else %}no{% endif %}")
       << dict << QStringLiteral("no") << NoError;
+
+  // operator in with bytearray
+  dict.clear();
+  dict.insert(QStringLiteral("colors"), QStringLiteral("green"));
+  QTest::newRow("if-tag-operator-in-ba-1") << QStringLiteral("{% if \"green\" in colors %}yes{% else %}no{% endif %}") << dict << QStringLiteral("yes") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("colors"), QStringLiteral("red"));
+  QTest::newRow("if-tag-operator-in-ba-2") << QStringLiteral("{% if \"green\" in colors %}yes{% else %}no{% endif %}") << dict << QStringLiteral("no") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("colors"), QByteArrayLiteral("green"));
+  QTest::newRow("if-tag-operator-in-ba-2") << QStringLiteral("{% if \"green\" in colors %}yes{% else %}no{% endif %}") << dict << QStringLiteral("yes") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("colors"), QByteArrayLiteral("red"));
+  QTest::newRow("if-tag-operator-in-ba-3") << QStringLiteral("{% if \"green\" in colors %}yes{% else %}no{% endif %}") << dict << QStringLiteral("no") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("color"), QByteArrayLiteral("green"));
+  dict.insert(QStringLiteral("colors"), QByteArrayLiteral("green"));
+  QTest::newRow("if-tag-operator-in-ba-2") << QStringLiteral("{% if color in colors %}yes{% else %}no{% endif %}") << dict << QStringLiteral("yes") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("color"), QByteArrayLiteral("green"));
+  dict.insert(QStringLiteral("colors"), QByteArrayLiteral("red"));
+  QTest::newRow("if-tag-operator-in-ba-3") << QStringLiteral("{% if color in colors %}yes{% else %}no{% endif %}") << dict << QStringLiteral("no") << NoError;
 
   // AND
 


### PR DESCRIPTION
Without this fix comparing a simple QString
to a string hardcoded on template fails,
it also fixes when the string is a QByteArray
so that this renders "true" if foo is either a
QString("foo") os a QByteArray("foo")

{% if foo = 'bar' %}true{% endif %}
or
{% if 'bar' = 'bar' %}true{% endif %}