### PR TITLE
Crash test cases discovered with the AFL fuzzer

### DIFF
--- a/templates/tests/testbuiltins.cpp
+++ b/templates/tests/testbuiltins.cpp
@@ -584,6 +584,17 @@ void TestBuiltinSyntax::testBasicSyntax_data()
                                   << TagSyntaxError;
   QTest::newRow("basic-syntax41") << "{{ abc|removetags:_(\'fred }}" << dict
                                   << QString() << TagSyntaxError;
+
+  // giant string handling
+  dict.clear();
+  QTest::newRow("basic-syntax42") << QStringLiteral("{% if xx == '%1 %}yes{% endif %}").arg(QString(25000, QChar::fromLatin1('a')))
+                                  << dict << QString() << TagSyntaxError;
+  QTest::newRow("basic-syntax43") << QStringLiteral("{% if xx == \"%1 %}yes{% endif %}").arg(QString(25000, QChar::fromLatin1('a')))
+                                  << dict << QString() << TagSyntaxError;
+  QTest::newRow("basic-syntax44") << QStringLiteral("{% if xx == '%1' %}yes{% endif %}").arg(QString(25000, QChar::fromLatin1('a')))
+                                  << dict << QString() << NoError;
+  QTest::newRow("basic-syntax45") << QStringLiteral("{% if xx == \"%1\" %}yes{% endif %}").arg(QString(25000, QChar::fromLatin1('a')))
+                                  << dict << QString() << NoError;
 }
 
 void TestBuiltinSyntax::testEnums_data()

--- a/templates/tests/testbuiltins.cpp
+++ b/templates/tests/testbuiltins.cpp
@@ -748,7 +748,9 @@ void TestBuiltinSyntax::testEnums_data()
   QTest::newRow("qt-enums06") << QStringLiteral("{{ Qt.Alignment.2.key }}")
                               << dict << QStringLiteral("AlignRight")
                               << NoError;
-  QTest::newRow("qt-enums06") << QStringLiteral("{{ Qt.DoesNotExist }}") << dict
+  QTest::newRow("qt-enums07") << QStringLiteral("{{ Qt.DoesNotExist }}") << dict
+                              << QString() << NoError;
+  QTest::newRow("qt-enums08") << QStringLiteral("{{ Qt }}") << dict
                               << QString() << NoError;
 }
 

--- a/templates/tests/testdefaulttags.cpp
+++ b/templates/tests/testdefaulttags.cpp
@@ -1299,6 +1299,12 @@ void TestDefaultTags::testForTag_data()
   QTest::newRow("for-tag-empty03")
       << QStringLiteral("{% for val in values %}{{ val }}{% empty %}values array not found{% endfor %}")
       << dict << QStringLiteral("values array not found") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("values"), QVariantList() << QStringLiteral("a") << QStringLiteral("b") << QStringLiteral("c"));
+  QTest::newRow("for-tag-degenerate01")
+      << QStringLiteral("{% for a,b|f in values %}{% endfor %}") << dict
+      << QStringLiteral("") << TagSyntaxError;
 }
 
 void TestDefaultTags::testIfEqualTag_data()

--- a/templates/tests/testdefaulttags.cpp
+++ b/templates/tests/testdefaulttags.cpp
@@ -1305,6 +1305,10 @@ void TestDefaultTags::testForTag_data()
   QTest::newRow("for-tag-degenerate01")
       << QStringLiteral("{% for a,b|f in values %}{% endfor %}") << dict
       << QStringLiteral("") << TagSyntaxError;
+
+  QTest::newRow("for-tag-degenerate02")
+      << QStringLiteral("{% for  in values reversed %}{% endfor %}") << dict
+      << QStringLiteral("") << TagSyntaxError;
 }
 
 void TestDefaultTags::testIfEqualTag_data()

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -759,6 +759,15 @@ void TestFilters::testStringFilters_data()
       << "a &amp;\nb a &\nb" << NoError;
 
   dict.clear();
+  QTest::newRow("filter-wordwrap03")
+      << QStringLiteral("{{xx|wordwrap}}") << dict
+      << "" << NoError;
+
+  QTest::newRow("filter-wordwrap04")
+      << QStringLiteral("{{|wordwrap}}") << dict
+      << "" << NoError;
+
+  dict.clear();
   dict.insert(QStringLiteral("a"), QStringLiteral("a&b"));
   dict.insert(QStringLiteral("b"),
               QVariant::fromValue(markSafe(QStringLiteral("a&b"))));

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -257,6 +257,12 @@ void TestFilters::testDateBasedFilters_data()
                                       << dict << QStringLiteral("1 day")
                                       << NoError;
 
+  dict.clear();
+  QTest::newRow("filter-timesince19") << QStringLiteral("{{xx|timesince}}") << dict
+                                      << QStringLiteral("") << NoError;
+  QTest::newRow("filter-timesince20") << QStringLiteral("{{|timesince}}") << dict
+                                      << QStringLiteral("") << NoError;
+
   //  Default compare with datetime.now()
 
   dict.clear();
@@ -354,6 +360,12 @@ void TestFilters::testDateBasedFilters_data()
   QTest::newRow("filter-timeuntil13") << QStringLiteral("{{ a|timeuntil:b }}")
                                       << dict << QStringLiteral("1 day")
                                       << NoError;
+
+  dict.clear();
+  QTest::newRow("filter-timeuntil14") << QStringLiteral("{{xx|timeuntil}}") << dict
+                                      << QStringLiteral("") << NoError;
+  QTest::newRow("filter-timeuntil15") << QStringLiteral("{{|timeuntil}}") << dict
+                                      << QStringLiteral("") << NoError;
 
   QDateTime d(QDate(2008, 1, 1));
 

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -1553,6 +1553,20 @@ void TestFilters::testIntegerFilters_data()
   QTest::newRow("filter-getdigit04") << QStringLiteral("{{ 123|get_digit:4 }}")
                                      << dict << QStringLiteral("123")
                                      << NoError;
+  QTest::newRow("filter-getdigit05") << QStringLiteral("{{ 123|get_digit:0 }}")
+                                     << dict << QStringLiteral("123")
+                                     << NoError;
+  QTest::newRow("filter-getdigit06") << QStringLiteral("{{ 123|get_digit:-1 }}")
+                                     << dict << QStringLiteral("123")
+                                     << NoError;
+
+  dict.clear();
+  QTest::newRow("filter-getdigit07") << QStringLiteral("{{xx|get_digit}}")
+                                     << dict << QStringLiteral("") << NoError;
+  QTest::newRow("filter-getdigit08") << QStringLiteral("{{|get_digit}}")
+                                     << dict << QStringLiteral("") << NoError;
+  QTest::newRow("filter-getdigit09") << QStringLiteral("{{xx|get_digit:\"\xc2\xb2\"}}")
+                                     << dict << QStringLiteral("") << NoError;
 }
 
 QTEST_MAIN(TestFilters)

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -806,6 +806,13 @@ void TestFilters::testStringFilters_data()
       << ".{{ a|center:\"5\" }}. .{{ b|center:\"5\" }}." << dict
       << QStringLiteral(". a&amp;b . . a&b .") << NoError;
 
+  QTest::newRow("filter-center03") << ".{{a|center:\"-1\"}}." << dict
+                                   << QStringLiteral(".a&amp;b.") << NoError;
+  QTest::newRow("filter-center04") << ".{{a|center:\"-1999999999\"}}." << dict
+                                   << QStringLiteral(".a&amp;b.") << NoError;
+  QTest::newRow("filter-center05") << ".{{a|center:\"1999999999\"}}." << dict
+                                   << QStringLiteral(".a&amp;b.") << NoError;
+
   dict.clear();
   dict.insert(QStringLiteral("a"), QStringLiteral("x&y"));
   dict.insert(QStringLiteral("b"),

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -620,6 +620,12 @@ void TestFilters::testStringFilters_data()
       << "{{ a|truncatewords:\"2\" }} {{ b|truncatewords:\"2\"}}" << dict
       << QStringLiteral("alpha &amp; ... alpha &amp; ...") << NoError;
 
+  dict.clear();
+  QTest::newRow("filter-truncatewords03") << "{{xx|truncatewords:\"0\"}}" << dict
+                                          << QString() << NoError;
+  QTest::newRow("filter-truncatewords04") << "{{xx|truncatewords:\"-1\"}}" << dict
+                                          << QString() << NoError;
+
   //  The "upper" filter messes up entities (which are case-sensitive),
   //  so it's not safe for non-escaping purposes.
 

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -1022,6 +1022,14 @@ void TestFilters::testListFilters_data()
       << dict << QStringLiteral("&b &b") << NoError;
 
   dict.clear();
+  QTest::newRow("filter-slice03")
+      << "{{xx|slice}}" << dict
+      << QStringLiteral("") << NoError;
+  QTest::newRow("filter-slice04")
+      << "{{|slice}}" << dict
+      << QStringLiteral("") << NoError;
+
+  dict.clear();
   QVariantList sublist;
   sublist << QVariant(QStringLiteral("<y"));
   dict.insert(QStringLiteral("a"), QVariantList() << QStringLiteral("x>")

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -1009,6 +1009,15 @@ void TestFilters::testListFilters_data()
       << dict << QStringLiteral("a&b a&b") << NoError;
 
   dict.clear();
+  dict.insert(QStringLiteral("empty_list"), QVariantList());
+  QTest::newRow("filter-random03")
+      << QStringLiteral("{{empty_list|random}}")
+      << dict << QStringLiteral("") << NoError;
+  QTest::newRow("filter-random04")
+      << QStringLiteral("{{|random}}")
+      << dict << QStringLiteral("") << NoError;
+
+  dict.clear();
   dict.insert(QStringLiteral("a"), QStringLiteral("a&b"));
   dict.insert(QStringLiteral("b"),
               QVariant::fromValue(markSafe(QStringLiteral("a&b"))));


### PR DESCRIPTION
As part of an evaluation I'm running to use the Grantlee libraries as a replacement for another more basic templating engine in another (unrelated) project, I took the liberty of running the excellent AFL fuzzer against the Grantlee_Templates library.

This pull request contains test cases reproducing the various crashes that were found. I have additional commits locally that resolve each test case, although I'm not including them here -- I'd prefer to defer those to you since my familiarity with the code base is limited. Most of these have straightforward fixes -- the exception is the PCRE stack overflow on large quoted strings, for which I see no easy fix.