### PR TITLE
Fix broken tag extension example code to compile cleanly

### DIFF
--- a/dox/extension.dox
+++ b/dox/extension.dox
@@ -96,38 +96,41 @@ namespace Grantlee
   Here is an example of a @gr_tag{current_time} tag which displays the current time.
 
   @code
-    class CurrentTimeTag : public Grantlee::AbstractNodeFactory
-    {
-      Grantlee::Node *getNode(const QString &tagContent, Parser *p) const
-      {
-        // You almost always want to use smartSplit.
-        QStringList parts = smartSplit(tagContent);
-        parts.removeFirst(); // Not interested in the name of the tag.
-
-        if (!parts.isEmpty())
-          // The remaining parts are the arguments to the tag. If an incorrect number of arguments
-          // is supplied, and exception should be thrown.
-          throw Grantlee::Exception( TagSyntaxError, "current_time does not take any arguments" );
-
-        return new CurrentTimeNode();
-      }
-    };
-
     class CurrentTimeNode : public Grantlee::Node
     {
-      Q_OBJECT
-    public:
-      CurrentTimeNode(QObject *parent)
-        : QObject(parent)
-      {
+          Q_OBJECT
 
-      }
+       public:
+          CurrentTimeNode( QObject *parent = nullptr )
+             : Grantlee::Node( parent )
+          {
+          }
 
-      void render( Grantlee::OutputStream *stream, Context *c) const
-      {
-        Q_UNUSED(c);
-        return QDateTime::currentDateTime().toString();
-      }
+          virtual void render( Grantlee::OutputStream *stream, Grantlee::Context *c) const override
+          {
+             Q_UNUSED(c);
+             
+             (*stream) <<  QDateTime::currentDateTime().toString();
+          }
+    };
+
+    class CurrentTimeTagFactory : public Grantlee::AbstractNodeFactory
+    {
+          Grantlee::Node *getNode(const QString &tagContent, Grantlee::Parser *p) const override
+          {
+             Q_UNUSED(p);
+
+             // You almost always want to use smartSplit.
+             QStringList parts = smartSplit(tagContent);
+             parts.removeFirst(); // Not interested in the name of the tag.
+
+             if (!parts.isEmpty())
+                // The remaining parts are the arguments to the tag. If an incorrect number of arguments
+                // is supplied, and exception should be thrown.
+                throw Grantlee::Exception( Grantlee::TagSyntaxError, "current_time does not take any arguments" );
+
+             return new CurrentTimeNode();
+          }
     };
   @endcode
 


### PR DESCRIPTION
* _CurrentTimeTag::getNode_ should be marked `override`
* _CurrentTimeTag::getNode_ 'p' should be marked `Q_UNUSED()`
* *Grantlee::* namespace missing in several places
* _CurrentTimeNode_ constructor needs to initialize the base class `Grantlee::Node`, not `QObject`
* _CurrentTimeNode_ constructor needs default initializer
* _CurrentTimeNode::render_ needs to be marked `const override`
* _CurrentTimeNode::render_ doesn't return anything, it needs to write it to the stream
* To be consistent with the builtins, _CurrentTimeTag_ should be called _CurrentTimeTagFactory_