### PR TITLE
Avoid recompilation after CMake run

### DIFF
--- a/templates/lib/CMakeLists.txt
+++ b/templates/lib/CMakeLists.txt
@@ -118,10 +118,6 @@ endif()
 
 configure_file(grantlee_test_export.h.in "${CMAKE_CURRENT_BINARY_DIR}/grantlee_test_export.h")
 
-file(READ "${CMAKE_CURRENT_BINARY_DIR}/grantlee_test_export.h" _content)
-
-file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/grantlee_templates_export.h" "${_content}")
-
 target_link_libraries(Grantlee_Templates
   LINK_PUBLIC Qt5::Core
 )

--- a/templates/lib/grantlee_test_export.h.in
+++ b/templates/lib/grantlee_test_export.h.in
@@ -1,2 +1,8 @@
+#ifndef GRANTLEE_TEST_EXPORT_H
+#define GRANTLEE_TEST_EXPORT_H
+
+#include "grantlee_templates_export.h"
 
 #define GRANTLEE_TESTS_EXPORT @GRANTLEE_TESTS_EXPORT@
+
+#endif

--- a/templates/lib/nulllocalizer_p.h
+++ b/templates/lib/nulllocalizer_p.h
@@ -21,6 +21,8 @@
 #ifndef GRANTLEE_NULLLOCALIZER_P_H
 #define GRANTLEE_NULLLOCALIZER_P_H
 
+#include "grantlee_test_export.h"
+
 #include "abstractlocalizer.h"
 
 namespace Grantlee


### PR DESCRIPTION
The generated grantlee_test_export.h always had its timestamp changed
after a CMake run, thus triggering to be several build targets to be out
of date and causing recompilation.

Fixes #35