### PR TITLE
Fix build with Qt 5.13 / GCC 8.2.

### DIFF
--- a/templates/lib/lexer_p.h
+++ b/templates/lib/lexer_p.h
@@ -24,7 +24,7 @@
 #include "textprocessingmachine_p.h"
 #include "token.h"
 
-template <typename T> class QList;
+#include <QList>
 
 namespace Grantlee
 {


### PR DESCRIPTION
At this point Grantlee doesn't build for me because QList is an
incomplete type. I think the compiler is right to complain, so I fix by
including the appropriate header.

Fixes issue #47.