### PR TITLE
Fix Q_GADGET property reading

### DIFF
--- a/templates/lib/metatype.cpp
+++ b/templates/lib/metatype.cpp
@@ -182,7 +182,7 @@ QVariant Grantlee::MetaType::lookup(const QVariant &object,
         return QVariant();
       }
       const auto mp = mo->property(idx);
-      return mp.readOnGadget(&object);
+      return mp.readOnGadget(object.constData());
     }
   }
 


### PR DESCRIPTION
We want to read from the object inside the variant here, not from the
variant itself.