### PR TITLE
Still allow custom meta types for Q_GADGETs

### DIFF
--- a/templates/lib/metatype.cpp
+++ b/templates/lib/metatype.cpp
@@ -178,11 +178,10 @@ QVariant Grantlee::MetaType::lookup(const QVariant &object,
     QMetaType mt(object.userType());
     if (mt.flags().testFlag(QMetaType::IsGadget)) {
       const auto idx = mo->indexOfProperty(property.toUtf8().constData());
-      if (idx < 0) {
-        return QVariant();
+      if (idx >= 0) {
+        const auto mp = mo->property(idx);
+        return mp.readOnGadget(object.constData());
       }
-      const auto mp = mo->property(idx);
-      return mp.readOnGadget(object.constData());
     }
   }
 


### PR DESCRIPTION
This is relevant when trying to make Q_GADGETs accessible that come from
a library that you can't easily extend by Q_PROPERTY, and restores
behavior compatibility with pre-Q_GADGET support.