### PR TITLE
Explicitly tests truthiness for float

### DIFF
--- a/templates/tests/testdefaulttags.cpp
+++ b/templates/tests/testdefaulttags.cpp
@@ -1048,7 +1048,8 @@ void TestDefaultTags::testIfTag_data()
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
 
-  auto r = 0.0;
+  // explicitly double
+  double r = 0.0;
   dict.insert(QStringLiteral("var"), r);
   QTest::newRow("if-truthiness09")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
@@ -1058,6 +1059,18 @@ void TestDefaultTags::testIfTag_data()
   QTest::newRow("if-truthiness10")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
+
+  // explicitly float
+  float f = 0.0f;
+  dict.insert(QStringLiteral("var"), f);
+  QTest::newRow("if-truthiness11")
+    << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}")
+    << dict << QStringLiteral("No") << NoError;
+  f = 7.1;
+  dict.insert(QStringLiteral("var"), f);
+  QTest::newRow("if-truthiness12")
+    << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}")
+    << dict << QStringLiteral("Yes") << NoError;
 
   dict.clear();
   QTest::newRow("if-tag-badarg01")


### PR DESCRIPTION
Explicitly tests the truthiness for float values in addition to double ones; related to this, switch the double variable from auto back to the explicit type, to stress the difference (and make sure it is always handled as double).

Very late followup of fbd54ee9a326cb1b1c438010882d02b1eaa08259.