### PR TITLE
Fix handling of the nested lists

### DIFF
--- a/textdocument/tests/plainmarkupbuildertest.cpp
+++ b/textdocument/tests/plainmarkupbuildertest.cpp
@@ -64,6 +64,7 @@ private Q_SLOTS:
   void testNewlinesThroughQTextCursor();
   void testBrInsideParagraph();
   void testLongDocument();
+  void testNestedList();
 };
 
 void TestPlainMarkupOutput::testSingleFormat()
@@ -634,6 +635,45 @@ void TestPlainMarkupOutput::testLongDocument()
   QVERIFY2(result.endsWith(QLatin1String("This is the end of the signature\n")),
            qPrintable(result));
   // qDebug() << result;
+}
+
+void TestPlainMarkupOutput::testNestedList()
+{
+    QTextDocument doc;
+    doc.setHtml(QStringLiteral("<ol>\n"
+                               "  <li>Elem1</li>\n"
+                               "  <li>Elem2\n"
+                               "    <ul>\n"
+                               "      <li>Subelem1</li>\n"
+                               "      <li>Subelem2</li>\n"
+                               "    </ul>\n"
+                               "  </li>\n"
+                               "  <li>Elem3</li>\n"
+                               "  <li>Elem4\n"
+                               "    <ul>\n"
+                               "      <li>Subelem3</li>\n"
+                               "      <li>Subelem4</li>\n"
+                               "    </ul>\n"
+                               "  </li>\n"
+                               "</ol>"
+                               "<ul type=\"circle\">\n"
+                               "  <li>Elem5</li>\n"
+                               "</ul>"));
+  auto hb = new PlainTextMarkupBuilder();
+  auto md = new MarkupDirector(hb);
+  md->processDocument(&doc);
+  auto result = hb->getResult();
+
+  const QString expected = QStringLiteral("     1. Elem1 \n"
+                                          "     2. Elem2 \n"
+                                          "         *  Subelem1 \n"
+                                          "         *  Subelem2 \n"
+                                          "     3. Elem3 \n"
+                                          "     4. Elem4 \n"
+                                          "         *  Subelem3 \n"
+                                          "         *  Subelem4 \n"
+                                          "     o  Elem5\n");
+  QCOMPARE(result, expected);
 }
 
 QTEST_MAIN(TestPlainMarkupOutput)


### PR DESCRIPTION
Add unittest based on [KDE Bug 332200](https://bugs.kde.org/show_bug.cgi?id=332200).

Without this patch, the nesting level can only increase, making the
following lists impossible:
```
 1. Elem1
   * SubElem1
 2. Elem2
   * SubElem2
```
Instead this patch suggest to determine the level of nestidness based on QTextBlockFormat::indent().