### PR TITLE
Don't use dot in folder name to prevent macOS issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(CMAKE_AUTOMOC ON)
 
 set(Grantlee5_MIN_PLUGIN_VERSION 0)
 
-set(Grantlee5_MAJOR_MINOR_VERSION_STRING "${Grantlee5_VERSION_MAJOR}.${Grantlee5_VERSION_MINOR}" )
+set(Grantlee5_MAJOR_MINOR_VERSION_STRING "${Grantlee5_VERSION_MAJOR}_${Grantlee5_VERSION_MINOR}" )
 
 set (LIB_SUFFIX "" CACHE STRING "Define suffix of library directory name (eg. '64')")
 


### PR DESCRIPTION
Grantlee5_MAJOR_MINOR_VERSION_STRING uses a dot between major
and minor component, which results in the lib/ subfolder
having the same name. This in turn causes an issue when bundling
grantlee with any software under macOS.

See following for reference:
https://bugs.kde.org/show_bug.cgi?id=420351
https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG201

This commit implements a  proposed workaround replacing
 '.' (dot) with '_'.

Fixes steveire/grantlee#64