### PR TITLE
[TextHTMLBuilder] Add support for inline images

### DIFF
--- a/textdocument/lib/abstractmarkupbuilder.h
+++ b/textdocument/lib/abstractmarkupbuilder.h
@@ -158,6 +158,14 @@ public:
   virtual void insertImage(const QString &url, qreal width, qreal height) = 0;
 
   /**
+    Insert a new inline image into the markup
+    @param image The image itself
+    @param width The width of the image
+    @param height The height of the image
+   */
+  virtual void insertImage(const QImage &image, qreal width, qreal height) = 0;
+
+  /**
     Begin a new list element in the markup.
     A list element contains list items, and may contain other lists.
     @param style The style of list to create.

--- a/textdocument/lib/bbcodebuilder.cpp
+++ b/textdocument/lib/bbcodebuilder.cpp
@@ -100,6 +100,13 @@ void BBCodeBuilder::insertImage(const QString &src, qreal width, qreal height)
   m_text.append(QStringLiteral("[IMG]%1[/IMG]").arg(src));
 }
 
+void BBCodeBuilder::insertImage(const QImage &image, qreal width, qreal height)
+
+  Q_UNUSED(image);
+  Q_UNUSED(width);
+  Q_UNUSED(height);
+}
+
 void BBCodeBuilder::beginList(QTextListFormat::Style type)
 {
   switch (type) {

--- a/textdocument/lib/bbcodebuilder.h
+++ b/textdocument/lib/bbcodebuilder.h
@@ -73,6 +73,7 @@ public:
   void addNewline() override;
 
   void insertImage(const QString &src, qreal width, qreal height) override;
+  void insertImage(const QImage &image, qreal width, qreal height) override;
 
   void beginList(QTextListFormat::Style type) override;
 

--- a/textdocument/lib/markupdirector.cpp
+++ b/textdocument/lib/markupdirector.cpp
@@ -477,8 +477,13 @@ MarkupDirector::processImage(QTextBlock::iterator it,
 {
   Q_UNUSED(doc)
   // TODO: Close any open format elements?
-  m_builder->insertImage(imageFormat.name(), imageFormat.width(),
-                         imageFormat.height());
+  QImage image = doc->resource(QTextDocument::ImageResource, QUrl(imageFormat.name())).value<QImage>();
+  if (image.isNull()) {
+    m_builder->insertImage(imageFormat.name(), imageFormat.width(),
+                           imageFormat.height());
+  } else {
+    m_builder->insertImage(image, imageFormat.width(), imageFormat.height());
+  }
   if (!it.atEnd())
     return ++it;
   return it;

--- a/textdocument/lib/plaintextmarkupbuilder.cpp
+++ b/textdocument/lib/plaintextmarkupbuilder.cpp
@@ -256,6 +256,15 @@ void PlainTextMarkupBuilder::insertImage(const QString &src, qreal width,
   d->m_text.append(QStringLiteral("[%1]").arg(ref));
 }
 
+void PlainTextMarkupBuilder::insertImage(const QImage &image, qreal width,
+                                         qreal height)
+{
+  Q_D(PlainTextMarkupBuilder);
+  Q_UNUSED(image)
+  Q_UNUSED(width)
+  Q_UNUSED(height)
+}
+
 void PlainTextMarkupBuilder::beginList(QTextListFormat::Style style)
 {
   Q_D(PlainTextMarkupBuilder);

--- a/textdocument/lib/plaintextmarkupbuilder.h
+++ b/textdocument/lib/plaintextmarkupbuilder.h
@@ -148,6 +148,7 @@ public:
   void insertHorizontalRule(int width = -1) override;
 
   void insertImage(const QString &src, qreal width, qreal height) override;
+  void insertImage(const QImage &image, qreal width, qreal height) override;
 
   void beginList(QTextListFormat::Style style) override;
 

--- a/textdocument/lib/texthtmlbuilder.cpp
+++ b/textdocument/lib/texthtmlbuilder.cpp
@@ -21,6 +21,7 @@
 #include "texthtmlbuilder.h"
 
 #include <QtCore/QList>
+#include <QtCore/QBuffer>
 #include <QtGui/QTextDocument>
 
 namespace Grantlee
@@ -297,6 +298,20 @@ void TextHTMLBuilder::insertImage(const QString &src, qreal width, qreal height)
 {
   Q_D(TextHTMLBuilder);
   d->m_text.append(QStringLiteral("<img src=\"%1\" ").arg(src));
+  if (width != 0)
+    d->m_text.append(QStringLiteral("width=\"%2\" ").arg(width));
+  if (height != 0)
+    d->m_text.append(QStringLiteral("height=\"%2\" ").arg(height));
+  d->m_text.append(QStringLiteral("/>"));
+}
+
+void TextHTMLBuilder::insertImage(const QImage &image, qreal width, qreal height)
+{
+  Q_D(TextHTMLBuilder);
+  QByteArray data;
+  QBuffer buffer(&data);
+  image.save(&buffer, "PNG");
+  d->m_text.append(QStringLiteral("<img src=\"data:image/png;base64,%1\" ").arg(QString::fromLatin1(data.toBase64())));
   if (width != 0)
     d->m_text.append(QStringLiteral("width=\"%2\" ").arg(width));
   if (height != 0)

--- a/textdocument/lib/texthtmlbuilder.h
+++ b/textdocument/lib/texthtmlbuilder.h
@@ -173,6 +173,7 @@ public:
   void insertHorizontalRule(int width = -1) override;
 
   void insertImage(const QString &src, qreal width, qreal height) override;
+  void insertImage(const QImage &image, qreal width, qreal height) override;
 
   void beginList(QTextListFormat::Style type) override;
 


### PR DESCRIPTION
Inline images might be stored inside QTextDocument resources. Those can be extracted from there and exported to HTML as <img src="data:image/png,base64:..." />

For plaintext it currently does nothing.

