### PR TITLE
Add missing license headers

### DIFF
--- a/examples/htmlapps/localrequestmanager.cpp
+++ b/examples/htmlapps/localrequestmanager.cpp
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #define QT_DISABLE_DEPRECATED_BEFORE 0
 

--- a/examples/htmlapps/localrequestmanager.h
+++ b/examples/htmlapps/localrequestmanager.h
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #ifndef LOCALREQUESTMANAGER_H
 #define LOCALREQUESTMANAGER_H

--- a/examples/htmlapps/main.cpp
+++ b/examples/htmlapps/main.cpp
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #include <QApplication>
 

--- a/examples/htmlapps/mainwindow.cpp
+++ b/examples/htmlapps/mainwindow.cpp
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #include "mainwindow.h"
 

--- a/examples/htmlapps/mainwindow.h
+++ b/examples/htmlapps/mainwindow.h
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H

--- a/examples/htmlapps/templatereply.cpp
+++ b/examples/htmlapps/templatereply.cpp
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #include "templatereply.h"
 

--- a/examples/htmlapps/templatereply.h
+++ b/examples/htmlapps/templatereply.h
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2011 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #ifndef TEMPLATEREPLY_H
 #define TEMPLATEREPLY_H

--- a/templates/lib/filter.cpp
+++ b/templates/lib/filter.cpp
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2009,2010 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #include "filter.h"
 

--- a/templates/tests/test_input.cpp
+++ b/templates/tests/test_input.cpp
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2010 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 QCoreApplication::translate("GR_FILENAME", "Birthday");
 QCoreApplication::translate("GR_FILENAME", "%n People", 0,

--- a/textdocument/tests/testutils.h
+++ b/textdocument/tests/testutils.h
@@ -1,3 +1,22 @@
+/*
+  This file is part of the Grantlee template system.
+
+  Copyright (c) 2010 Stephen Kelly <steveire@gmail.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either version
+  2.1 of the Licence, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
 
 #ifndef GRANTLEE_TEST_UTILS_H
 #define GRANTLEE_TEST_UTILS_H


### PR DESCRIPTION
Hi Stephen,

while preparing the KF integration of Grantlee, I came across these files which so far are missing out respective license headers.

I prepared a commit in your name to fix that, so all work left for you is to accept and merge :)

Hoping you give this a look soonish,

Cheers
Friedrich