### PR TITLE
remove unneeded moc include

### DIFF
--- a/templates/lib/nodebuiltins.cpp
+++ b/templates/lib/nodebuiltins.cpp
@@ -39,5 +39,3 @@ void VariableNode::render(OutputStream *stream, Context *c) const
     return;
   streamValueInContext(stream, v, c);
 }
-
-#include "moc_nodebuiltins_p.cpp"


### PR DESCRIPTION
Hello,

while browsing the code and went through the file dependencies I stumbled upon this moc include at the end of a cpp file that is not necessary. Removing it also results in a successful build. Can you confirm?