### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.directory
+CMakeLists.txt.user
+.cmake/
+/.clang-format
+/compile_commands.json
+.clangd
+.cache
+.idea
+/cmake-build*


### PR DESCRIPTION
It was done for compile_commands.json cleanup in the first place.
Other entries were copied from KDE/marble repo as well.

See also: https://invent.kde.org/sdk/kdesrc-build/-/issues/86