### PR TITLE
examples/contacts Qt6WebKitWidgets does not exist. KDE Frameworks 6 s…

### DIFF
--- a/examples/contacts/CMakeLists.txt
+++ b/examples/contacts/CMakeLists.txt
@@ -20,11 +20,9 @@ target_link_libraries(
 )
 
 if (GRANTLEE_BUILD_WITH_QT6)
-  find_package(Qt6WebKitWidgets REQUIRED)
   find_package(Qt6LinguistTools REQUIRED)
   target_link_libraries(
     contacts_linguist
-    Qt6::WebKitWidgets
   )
   set(lupdate_exe Qt6::lupdate)
   set(lrelease_exe Qt6::lrelease)

--- a/examples/htmlapps/CMakeLists.txt
+++ b/examples/htmlapps/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(htmlapps
 
 if (GRANTLEE_BUILD_WITH_QT6)
   target_link_libraries(htmlapps
-    Qt6::WebKitWidgets
   )
 else()
   target_link_libraries(htmlapps


### PR DESCRIPTION
…hould not depend on Qt6WebKitWidgets

KDE PIM module grantlee-editor depends on this git repository. grantlee/examples/contacts/CMakeLists.txt find_package(Qt6WebKitWidgets REQUIRED)