### PR TITLE
Fix build error when using Qt 6.4

### DIFF
--- a/templates/lib/taglibraryinterface.h
+++ b/templates/lib/taglibraryinterface.h
@@ -24,6 +24,7 @@
 #include "outputstream.h"
 
 #include <QtCore/QHash>
+#include <QtCore/QObject>
 
 namespace Grantlee
 {


### PR DESCRIPTION
Building against Qt 6.4 fails with the following:
```
[107/156] Building CXX object templates/i18n/CMakeFiles/grantlee_i18ntags.dir/i18ntags.cpp.o
FAILED: templates/i18n/CMakeFiles/grantlee_i18ntags.dir/i18ntags.cpp.o 
/usr/bin/c++ -DQT_CORE_LIB -DQT_DISABLE_DEPRECATED_BEFORE=0x050d00 -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_KEYWORDS -DQT_NO_URL_CAST_FROM_STRING -DQT_STRICT_ITERATORS -DQT_USE_QSTRINGBUILDER -Dgrantlee_i18ntags_EXPORTS -I/home/sandroandrade/devel/grantlee/build/templates/i18n -I/home/sandroandrade/devel/grantlee/templates/i18n -I/home/sandroandrade/devel/grantlee/build/templates/i18n/grantlee_i18ntags_autogen/include -I/home/sandroandrade/devel/grantlee/build/templates/lib -I/home/sandroandrade/devel/grantlee/templates/lib -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib/qt6/mkspecs/linux-g++ -Wshadow -Wnon-virtual-dtor -Wno-long-long -Wundef -Wcast-align -Wchar-subscripts -Wall -W -Wpointer-arith -Wformat-security -fno-check-new -fno-common -pedantic-errors -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -MD -MT templates/i18n/CMakeFiles/grantlee_i18ntags.dir/i18ntags.cpp.o -MF templates/i18n/CMakeFiles/grantlee_i18ntags.dir/i18ntags.cpp.o.d -o templates/i18n/CMakeFiles/grantlee_i18ntags.dir/i18ntags.cpp.o -c /home/sandroandrade/devel/grantlee/templates/i18n/i18ntags.cpp
In file included from /home/sandroandrade/devel/grantlee/templates/i18n/i18ntags.h:24,
                 from /home/sandroandrade/devel/grantlee/templates/i18n/i18ntags.cpp:21:
/home/sandroandrade/devel/grantlee/templates/lib/taglibraryinterface.h:107:21: error: expected identifier before string constant
  107 |                     "org.grantlee.TagLibraryInterface/1.0")
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sandroandrade/devel/grantlee/templates/lib/taglibraryinterface.h:107:21: error: expected ‘,’ or ‘...’ before string constant
In file included from /usr/include/qt6/QtCore/qdebug.h:11,
                 from /usr/include/qt6/QtCore/qvariant.h:11,
                 from /usr/include/qt6/QtCore/qlocale.h:7,
                 from /usr/include/qt6/QtCore/QLocale:1,
                 from /home/sandroandrade/devel/grantlee/templates/lib/abstractlocalizer.h:26,
                 from /home/sandroandrade/devel/grantlee/templates/lib/context.h:24,
                 from /home/sandroandrade/devel/grantlee/templates/lib/node.h:26,
                 from /home/sandroandrade/devel/grantlee/templates/i18n/i18n.h:24,
                 from /home/sandroandrade/devel/grantlee/templates/i18n/i18ntags.h:26:
/usr/include/qt6/QtCore/qcontiguouscache.h:16:1: error: expected constructor, destructor, or type conversion before ‘struct’
   16 | struct Q_CORE_EXPORT QContiguousCacheData
      | ^~~~~~
/usr/include/qt6/QtCore/qcontiguouscache.h:34:1: error: expected class-name before ‘{’ token
   34 | {
      | ^
/usr/include/qt6/QtCore/qcontiguouscache.h: In member function ‘QContiguousCache<T>::Data* QContiguousCache<T>::allocateData(qsizetype)’:
/usr/include/qt6/QtCore/qcontiguouscache.h:238:32: error: ‘QContiguousCacheData’ has not been declared
  238 |     return static_cast<Data *>(QContiguousCacheData::allocateData(sizeof(Data) + (aalloc - 1) * sizeof(T), alignof(Data)));
      |                                ^~~~~~~~~~~~~~~~~~~~
[116/156] Building CXX object templates/i18n/CMakeFiles/grantlee_i18ntags.dir/with_locale.cpp.o
ninja: build stopped: subcommand failed.
```