### PR TITLE
examples fixes for qt6

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,12 +10,6 @@ else()
   set(prefixPath ${CMAKE_BINARY_DIR}/${CMAKE_PREFIX_PATH})
 endif()
 
-ExternalProject_Add(books
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/books
-  INSTALL_COMMAND ""
-  CMAKE_ARGS
-    -DCMAKE_PREFIX_PATH=${prefixPath}
-)
 ExternalProject_Add(codegen
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/codegen
   INSTALL_COMMAND ""
@@ -25,6 +19,13 @@ ExternalProject_Add(codegen
 )
 
 if (NOT GRANTLEE_BUILD_WITH_QT6)
+  ExternalProject_Add(books
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/books
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+      -DCMAKE_PREFIX_PATH=${prefixPath}
+  )
+
   ExternalProject_Add(contacts
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/contacts
     INSTALL_COMMAND ""
@@ -40,12 +41,12 @@ if (NOT GRANTLEE_BUILD_WITH_QT6)
       -DCMAKE_PREFIX_PATH=${prefixPath}
     DEPENDS contacts
   )
-endif()
 
-ExternalProject_Add(textedit
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/textedit
-  INSTALL_COMMAND ""
-  CMAKE_ARGS
-    -DCMAKE_PREFIX_PATH=${prefixPath}
-  DEPENDS htmlapps
-)
+  ExternalProject_Add(textedit
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/textedit
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+      -DCMAKE_PREFIX_PATH=${prefixPath}
+    DEPENDS htmlapps
+  )
+endif()

--- a/examples/books/CMakeLists.txt
+++ b/examples/books/CMakeLists.txt
@@ -16,8 +16,13 @@ get_filename_component(Grantlee_PLUGIN_DIR ${Grantlee_PLUGIN_DIR} PATH)
 
 configure_file(grantlee_paths.h.cmake ${PROJECT_BINARY_DIR}/grantlee_paths.h)
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Sql REQUIRED)
+if (GRANTLEE_BUILD_WITH_QT6)
+    find_package(Qt6Widgets REQUIRED)
+    find_package(Qt6Sql REQUIRED)
+else()
+    find_package(Qt5Widgets REQUIRED)
+    find_package(Qt5Sql REQUIRED)
+endif()
 
 add_executable(books
   main.cpp
@@ -31,6 +36,7 @@ target_link_libraries(
   books
   Grantlee5::Templates
 )
+
 if (GRANTLEE_BUILD_WITH_QT6)
     target_link_libraries(books
       Qt6::Widgets

--- a/examples/codegen/CMakeLists.txt
+++ b/examples/codegen/CMakeLists.txt
@@ -16,7 +16,7 @@ get_filename_component(Grantlee_PLUGIN_DIR ${Grantlee_PLUGIN_DIR} PATH)
 
 configure_file(grantlee_paths.h.cmake ${PROJECT_BINARY_DIR}/grantlee_paths.h)
 
-qt5_add_resources(
+qt_add_resources(
   codegen_example_RCS_SRCS
   custom_tags.qrc
   OPTIONS -root "/plugins/grantlee/${Grantlee5_VERSION_MAJOR}.${Grantlee5_VERSION_MINOR}/"
@@ -35,12 +35,17 @@ add_executable(codegen
 )
 target_compile_definitions(codegen PRIVATE QT_DISABLE_DEPRECATED_BEFORE=0)
 
-find_package(Qt5Widgets REQUIRED)
+if (GRANTLEE_BUILD_WITH_QT6)
+    find_package(Qt6Widgets REQUIRED)
+else()
+    find_package(Qt5Widgets REQUIRED)
+endif()
 
 target_link_libraries(
   codegen
   Grantlee5::Templates
 )
+
 if (GRANTLEE_BUILD_WITH_QT6)
     target_link_libraries(codegen
       Qt6::Widgets

--- a/examples/codegen/designwidget.h
+++ b/examples/codegen/designwidget.h
@@ -34,7 +34,7 @@ class DesignWidget : public QWidget
 {
   Q_OBJECT
 public:
-  DesignWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+  DesignWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::Widget);
 
   Grantlee::Context getContext();
 

--- a/examples/codegen/mainwindow.h
+++ b/examples/codegen/mainwindow.h
@@ -36,7 +36,7 @@ class MainWindow : public QMainWindow
 {
   Q_OBJECT
 public:
-  MainWindow(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  MainWindow(QWidget *parent = 0, Qt::WindowFlags flags = Qt::Widget);
   virtual ~MainWindow();
 
 private Q_SLOTS:

--- a/examples/contacts/mainwindow.h
+++ b/examples/contacts/mainwindow.h
@@ -39,7 +39,7 @@ class MainWindow : public QWidget
   Q_OBJECT
 public:
   MainWindow(const QString &templateDir, QWidget *parent = 0,
-             Qt::WindowFlags f = 0);
+             Qt::WindowFlags f = Qt::Widget);
 
 protected:
   virtual void initLocalizer();
@@ -65,7 +65,7 @@ template <typename T> class AppMainWindow : public MainWindow
 {
 public:
   AppMainWindow(const QString &templateDir, QWidget *parent = 0,
-                Qt::WindowFlags f = 0)
+                Qt::WindowFlags f = Qt::Widget)
       : MainWindow(templateDir, parent, f)
   {
   }

--- a/examples/textedit/CMakeLists.txt
+++ b/examples/textedit/CMakeLists.txt
@@ -3,7 +3,12 @@ cmake_minimum_required(VERSION 3.5)
 project(textedit_grantlee)
 
 find_package(Grantlee5 REQUIRED)
-find_package(Qt5Widgets REQUIRED)
+
+if (GRANTLEE_BUILD_WITH_QT6)
+    find_package(Qt6Widgets REQUIRED)
+else()
+    find_package(Qt5Widgets REQUIRED)
+endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -47,13 +52,13 @@ target_link_libraries(
 )
 
 if (GRANTLEE_BUILD_WITH_QT6)
-  target_link_libraries(
-    textedit
-    Qt6::Widgets
-  )
+    target_link_libraries(
+      textedit
+      Qt6::Widgets
+    )
 else()
-  target_link_libraries(
-    textedit
-    Qt5::Widgets
-  )
+    target_link_libraries(
+      textedit
+      Qt5::Widgets
+    )
 endif()


### PR DESCRIPTION
- fixes for building examples with Qt6
- don't build books and textedit with Qt6 due to erros

Fixed build of `codegen` with Qt6. `books` still doesn't build with error:
```
bookdelegate.cpp:81:5: error: use of undeclared identifier 'drawFocus'
    drawFocus(
    ^
```

So In a optional commit moved `books` under non-Qt6 guard. As well as `textedit`, which also fails with error:

```
textedit.cpp:56:10: fatal error: 'QTextCodec' file not found`
```

I tried to add `Qt6::Core5Compat`, but I faced with 10 errors.

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>
